### PR TITLE
Allow env is being different than test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Add to your Gemfile:
 gem "spring-commands-spinach"
 ```
 
+### Spinach Environment
+If you need to run spinach a different `RAILS_ENV` other than `"test"` then we can run spinach as:
+
+```bash
+SPINACH_ENV="feature" bin/spinach
+```
+
+Or at the first line of `bin/spinach`:
+
+```ruby
+ENV["SPINACH_ENV"]="feature"
+```
+
 ## Credits
 
 This gem was inspired by Jon Leighton's spring-commands-cucumber gem

--- a/lib/spring/commands/spinach.rb
+++ b/lib/spring/commands/spinach.rb
@@ -2,15 +2,16 @@ module Spring
   module Commands
     class Spinach
       def env(*)
-        "test"
+        ENV["SPINACH_ENV"] || "test"
       end
 
       def exec_name
         "spinach"
       end
+
     end
 
     Spring.register_command "spinach", Spinach.new
-    Spring::Commands::Rake.environment_matchers[/^spinach($|:)/] = "test"
+    Spring::Commands::Rake.environment_matchers[/^spinach($|:)/] = Spring::Commands::Spinach.new.env
   end
 end

--- a/lib/spring/commands/spinach.rb
+++ b/lib/spring/commands/spinach.rb
@@ -8,7 +8,6 @@ module Spring
       def exec_name
         "spinach"
       end
-
     end
 
     Spring.register_command "spinach", Spinach.new


### PR DESCRIPTION
If you need to run spinach a different `RAILS_ENV` other than `"test"` then we can run spinach as:

``` bash
SPINACH_ENV="feature" bin/spinach
```

Or at the first line of `bin/spinach`:

``` ruby
ENV["SPINACH_ENV"]="feature"
```
